### PR TITLE
Sleep 2 seconds after account creation

### DIFF
--- a/churner/churner.go
+++ b/churner/churner.go
@@ -119,6 +119,10 @@ func (c *Churner) RegisterAccount(ctx context.Context) error {
 	}
 
 	c.acmeAccount = account
+
+	// Account creation isn't immediately consistent across all DCs.
+	// Sleep 2 seconds to avoid any potential problems.
+	time.Sleep(2 * time.Second)
 	return nil
 }
 


### PR DESCRIPTION
We've rarely seen the following error:

churning: creating new order: attempt 1: https://acme-v02.api.letsencrypt.org/acme/new-order: HTTP 400 urn:ietf:params:acme:error:accountDoesNotExist - Account "https://acme-v02.api.letsencrypt.org/acme/acct/924981257" not found: wrapError null

A sleep is a bit of a bodge, but I am hopeful it's an acceptable one.