### PR TITLE
Upload artifacts to S3 in the release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,9 @@ on:
     tags:
       - v*
 
+permissions:
+  id-token: write # Needed to request JWT for OIDC
+
 jobs:
   release:
     runs-on: ubuntu-latest
@@ -16,8 +19,10 @@ jobs:
         with:
           go-version: 1.21
       - run: ./build-release.sh
-      - name: upload
-        uses: actions/upload-artifact@v4
+      # Upload to S3:
+      - uses: aws-actions/configure-aws-credentials@v3
         with:
-          path: "build/*.zip"
-          if-no-files-found: error
+          role-to-assume: arn:aws:iam::338276578713:role/crl-monitor-github-action-role
+          aws-region: us-west-2
+      - run: aws s3 cp build/checker.zip s3://crl-monitor-artifacts/${{ github.ref_name }}/
+      - run: aws s3 cp build/churner.zip s3://crl-monitor-artifacts/${{ github.ref_name }}/


### PR DESCRIPTION
This uploads checker.zip and churner.zip to an S3 bucket in the release.yml workflow that is run on tags.
The lambdas can then be deployed from S3, instead of requiring the files be copied manually.

For some reference material, see https://github.com/aws-actions/configure-aws-credentials

After merging, I will create a v0.1.0 tag to check the workflow works as expected.