### PR TITLE
Update crl-checker to use math/rand/v2, generate RSA keys sometimes

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -15,5 +15,6 @@ linters:
     - unused
     - wastedassign
 linters-settings:
-  errcheck:
-    ignore: fmt:[FS]?[Pp]rint*,io:Write,os:Remove,net/http:Write,net:Write,encoding/binary:Write
+  gosec:
+    excludes:
+      - G404

--- a/checker/earlyremoval/check.go
+++ b/checker/earlyremoval/check.go
@@ -5,7 +5,7 @@ import (
 	"crypto/x509"
 	"log"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"time"
 
 	"github.com/letsencrypt/boulder/crl/checker"

--- a/checker/earlyremoval/check_test.go
+++ b/checker/earlyremoval/check_test.go
@@ -68,8 +68,7 @@ func TestSample(t *testing.T) {
 	require.Empty(t, sample([]int{}, 999))
 
 	var data []int
-	// Generate a random array for tests.  Insecure RNG is fine.
-	// #nosec G404
+	// Generate a random array for tests.
 	length := 100 + rand.IntN(300)
 	for i := 0; i < length; i++ {
 		data = append(data, i)

--- a/checker/earlyremoval/check_test.go
+++ b/checker/earlyremoval/check_test.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"crypto/x509"
 	"math/big"
-	"math/rand"
+	"math/rand/v2"
 	"testing"
 	"time"
 
@@ -70,7 +70,7 @@ func TestSample(t *testing.T) {
 	var data []int
 	// Generate a random array for tests.  Insecure RNG is fine.
 	// #nosec G404
-	length := 100 + rand.Intn(300)
+	length := 100 + rand.IntN(300)
 	for i := 0; i < length; i++ {
 		data = append(data, i)
 	}

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -164,7 +164,6 @@ func (c *Churner) Churn(ctx context.Context) error {
 
 // randomKey generates either an ecdsa or rsa private key
 func randomKey() (crypto.Signer, error) {
-	// #nosec G404
 	if mathrand.IntN(2) == 0 {
 		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	} else {
@@ -175,7 +174,6 @@ func randomKey() (crypto.Signer, error) {
 // randDomains picks the domains to include on the certificate.
 // We put a single domain which includes the current time and a random value.
 func randDomains(baseDomain string) []string {
-	// #nosec G404
 	domain := fmt.Sprintf("r%dZ%x.%s", time.Now().Unix(), mathrand.Uint32(), baseDomain)
 	return []string{domain}
 }

--- a/churner/churner.go
+++ b/churner/churner.go
@@ -164,6 +164,7 @@ func (c *Churner) Churn(ctx context.Context) error {
 
 // randomKey generates either an ecdsa or rsa private key
 func randomKey() (crypto.Signer, error) {
+	// #nosec G404
 	if mathrand.IntN(2) == 0 {
 		return ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	} else {
@@ -174,6 +175,7 @@ func randomKey() (crypto.Signer, error) {
 // randDomains picks the domains to include on the certificate.
 // We put a single domain which includes the current time and a random value.
 func randDomains(baseDomain string) []string {
+	// #nosec G404
 	domain := fmt.Sprintf("r%dZ%x.%s", time.Now().Unix(), mathrand.Uint32(), baseDomain)
 	return []string{domain}
 }

--- a/churner/churner_test.go
+++ b/churner/churner_test.go
@@ -18,7 +18,7 @@ func TestRandDomains(t *testing.T) {
 	base := "revoked.invalid"
 	domains := randDomains(base)
 	require.Len(t, domains, 1)
-	require.Regexp(t, regexp.MustCompile(`r[0-9]{10}z[0-9a-f]{4}\.`+regexp.QuoteMeta(base)), domains[0])
+	require.Regexp(t, regexp.MustCompile(`r[0-9]{10}Z[0-9a-f]+\.`+regexp.QuoteMeta(base)), domains[0])
 
 	second := randDomains(base)
 	require.NotEqual(t, domains, second, "Domains should be different each invocation")


### PR DESCRIPTION
This switches to math/rand/v2, and adds a bit more randomization while we're here.

We randomly generate either an ECDSA or RSA key to ensure we split issuance across all intermediates.

The random domain name setup is simplified by using a random Uint32 instead of a byte buffer.
