### PR TITLE
Check for CRLDistributionPoint in certificates.

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -208,7 +208,7 @@ func (c *Checker) lookForSeenCerts(ctx context.Context, crl *x509.RevocationList
 
 	err = c.db.DeleteSerials(ctx, seenSerials)
 	if err != nil {
-		return fmt.Errorf("failed to delete from db: %v", err)
+		errs = append(errs, fmt.Errorf("failed to delete from db: %v", err))
 	}
 	return errors.Join(errs...)
 }

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -115,7 +115,7 @@ func TestCheck(t *testing.T) {
 		},
 	}, testdata.Now))
 	// The "certificates-have-crldp" object should error because the certificate CRL is a mismatch
-	require.ErrorContains(t, checker.Check(ctx, bucket, certificatesHaveCRLDP, nil), "has CRLDistributionPoint")
+	require.ErrorContains(t, checker.Check(ctx, bucket, certificatesHaveCRLDP, nil), "has non-matching CRLDistributionPoint")
 }
 
 func Test_nameID(t *testing.T) {

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -31,13 +31,17 @@ func TestCheck(t *testing.T) {
 	issuerName := nameID(issuer)
 	shouldBeGood := fmt.Sprintf("%s/should-be-good.crl", issuerName)
 	earlyRemoval := fmt.Sprintf("%s/early-removal.crl", issuerName)
-	shouldBeGoodIDP := fmt.Sprintf("http://idp/%s", shouldBeGood)
-	earlyRemovalIDP := fmt.Sprintf("http://idp/%s", earlyRemoval)
+	certificatesHaveCRLDP := fmt.Sprintf("%s/certificates-have-crldp.crl", issuerName)
+	shouldBeGoodURL := fmt.Sprintf("http://idp/%s", shouldBeGood)
+	earlyRemovalURL := fmt.Sprintf("http://idp/%s", earlyRemoval)
+	certificatesHaveCRLDPURL := fmt.Sprintf("http://idp/%s", certificatesHaveCRLDP)
 
-	crl1der := testdata.MakeCRL(t, &testdata.CRL1, shouldBeGoodIDP, issuer, key)
-	crl2der := testdata.MakeCRL(t, &testdata.CRL2, shouldBeGoodIDP, issuer, key)
-	crl3der := testdata.MakeCRL(t, &testdata.CRL3, earlyRemovalIDP, issuer, key)
-	crl4der := testdata.MakeCRL(t, &testdata.CRL4, earlyRemovalIDP, issuer, key)
+	crl1der := testdata.MakeCRL(t, &testdata.CRL1, shouldBeGoodURL, issuer, key)
+	crl2der := testdata.MakeCRL(t, &testdata.CRL2, shouldBeGoodURL, issuer, key)
+	crl3der := testdata.MakeCRL(t, &testdata.CRL3, earlyRemovalURL, issuer, key)
+	crl4der := testdata.MakeCRL(t, &testdata.CRL4, earlyRemovalURL, issuer, key)
+	crl6der := testdata.MakeCRL(t, &testdata.CRL6, certificatesHaveCRLDPURL, issuer, key)
+	crl7der := testdata.MakeCRL(t, &testdata.CRL7, certificatesHaveCRLDPURL, issuer, key)
 
 	data := map[string][]storagemock.MockObject{
 		shouldBeGood: {
@@ -60,6 +64,16 @@ func TestCheck(t *testing.T) {
 				Data:      crl3der,
 			},
 		},
+		certificatesHaveCRLDP: {
+			{
+				VersionID: "the-current-version",
+				Data:      crl7der, // CRL6 has serial 4213, which has a CRLDP
+			},
+			{
+				VersionID: "the-previous-version",
+				Data:      crl6der,
+			},
+		},
 	}
 	bucket := "crl-test"
 
@@ -74,11 +88,12 @@ func TestCheck(t *testing.T) {
 
 	ctx := context.Background()
 
-	// Watch the first revoked cert's serial
+	// Insert some serials in the "unseen-certificates" table to be checked.
 	serial := testdata.CRL1.RevokedCertificateEntries[0].SerialNumber
 	require.NoError(t, checker.db.AddCert(ctx, &x509.Certificate{SerialNumber: serial}, testdata.Now))
 	shouldNotBeSeen := big.NewInt(12345)
 	require.NoError(t, checker.db.AddCert(ctx, &x509.Certificate{SerialNumber: shouldNotBeSeen}, testdata.Now))
+	mismatchCRLDistributionPoint := big.NewInt(4213)
 
 	require.NoError(t, checker.Check(ctx, bucket, shouldBeGood, nil))
 
@@ -92,6 +107,15 @@ func TestCheck(t *testing.T) {
 
 	// The "early-removal" object should error on a certificate removed early
 	require.ErrorContains(t, checker.Check(ctx, bucket, earlyRemoval, nil), "early removal of 1 certificates detected!")
+
+	require.NoError(t, checker.db.AddCert(ctx, &x509.Certificate{
+		SerialNumber: mismatchCRLDistributionPoint,
+		CRLDistributionPoints: []string{
+			"http://example.com",
+		},
+	}, testdata.Now))
+	// The "certificates-have-crldp" object should error because the certificate CRL is a mismatch
+	require.ErrorContains(t, checker.Check(ctx, bucket, certificatesHaveCRLDP, nil), "has CRLDistributionPoint")
 }
 
 func Test_nameID(t *testing.T) {

--- a/checker/testdata/testdata.go
+++ b/checker/testdata/testdata.go
@@ -70,6 +70,28 @@ var CRL5 = x509.RevocationList{
 	RevokedCertificateEntries: nil,
 }
 
+// CRL6 contains serial 4213, which will have a CRLDistributionPoint
+// that doesn't match the CRL.
+var CRL6 = x509.RevocationList{
+	ThisUpdate: Now.Add(4 * time.Hour),
+	NextUpdate: Now.Add(24 * time.Hour),
+	Number:     big.NewInt(1),
+	RevokedCertificateEntries: []x509.RevocationListEntry{
+		{SerialNumber: big.NewInt(4213), RevocationTime: Now},
+	},
+}
+
+// CRL7 also contains serial 4213, which will have a CRLDistributionPoint
+// that doesn't match the CRL.
+var CRL7 = x509.RevocationList{
+	ThisUpdate: Now.Add(5 * time.Hour),
+	NextUpdate: Now.Add(25 * time.Hour),
+	Number:     big.NewInt(2),
+	RevokedCertificateEntries: []x509.RevocationListEntry{
+		{SerialNumber: big.NewInt(4213), RevocationTime: Now},
+	},
+}
+
 func MakeIssuer(t *testing.T) (*x509.Certificate, crypto.Signer) {
 	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
 	require.NoError(t, err)

--- a/db/db.go
+++ b/db/db.go
@@ -48,7 +48,7 @@ func New(ctx context.Context, table, dynamoEndpoint string) (*Database, error) {
 type CertMetadata struct {
 	CertKey
 	RevocationTime       time.Time `dynamodbav:"RT,unixtime"`
-	CRLDistributionPoint string    `dynamodbav:"DP,string"`
+	CRLDistributionPoint string    `dynamodbav:"DP,string,omitempty"`
 }
 
 // CertKey is the DynamoDB primary key, which is the serial number.

--- a/db/integration_test.go
+++ b/db/integration_test.go
@@ -23,7 +23,7 @@ func TestIntegrationDynamoDB(t *testing.T) {
 	cfg.Credentials = aws.CredentialsProviderFunc(func(ctx context.Context) (aws.Credentials, error) {
 		return aws.Credentials{AccessKeyID: "Bogus", SecretAccessKey: "Bogus"}, nil
 	})
-	handle, err := db.New("unseen-certificates", cfg)
+	handle, err := db.New(context.Background(), "unseen-certificates", "http://localhost:8000")
 	require.NoError(t, err)
 
 	smoketest(t, handle)


### PR DESCRIPTION
If a certificate has a CRLDistributionPoint, it will be stored in the database in a new "DP" column.

At check time, each CRL must have exactly one IssuingDistributionPoint. When a certificate is seen, its CRLDistributionPoint (if any) will be compared to the IssuingDistributionPoint of the CRL it was seen on. If they differ, error.