### PR TITLE
churner: replace Z with z

### DIFF
--- a/churner/churner.go
+++ b/churner/churner.go
@@ -174,7 +174,7 @@ func randomKey() (crypto.Signer, error) {
 // randDomains picks the domains to include on the certificate.
 // We put a single domain which includes the current time and a random value.
 func randDomains(baseDomain string) []string {
-	domain := fmt.Sprintf("r%dZ%x.%s", time.Now().Unix(), mathrand.Uint32(), baseDomain)
+	domain := fmt.Sprintf("r%dz%x.%s", time.Now().Unix(), mathrand.Uint32(), baseDomain)
 	return []string{domain}
 }
 

--- a/churner/churner_test.go
+++ b/churner/churner_test.go
@@ -18,7 +18,7 @@ func TestRandDomains(t *testing.T) {
 	base := "revoked.invalid"
 	domains := randDomains(base)
 	require.Len(t, domains, 1)
-	require.Regexp(t, regexp.MustCompile(`r[0-9]{10}Z[0-9a-f]+\.`+regexp.QuoteMeta(base)), domains[0])
+	require.Regexp(t, regexp.MustCompile(`r[0-9]{10}z[0-9a-f]+\.`+regexp.QuoteMeta(base)), domains[0])
 
 	second := randDomains(base)
 	require.NotEqual(t, domains, second, "Domains should be different each invocation")


### PR DESCRIPTION
The acmez package does a case-sensitive comparison between the issued certificate and the requested names. If we request an uppercase name and the CA downcases it (as Let's Encrypt does), that produces an error.