### PR TITLE
churner: fetch and lint CRL at issuance time

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"log"
 	"math/big"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -79,7 +78,6 @@ func NewFromEnv(ctx context.Context) (*Checker, error) {
 	}
 
 	baf := expiry.BoulderAPIFetcher{
-		Client:  http.DefaultClient,
 		BaseURL: boulderBaseURL,
 	}
 

--- a/checker/expiry/boulder_api.go
+++ b/checker/expiry/boulder_api.go
@@ -5,57 +5,14 @@ import (
 	"crypto/x509"
 	"encoding/pem"
 	"fmt"
-	"io"
 	"math/big"
-	"net/http"
 	"time"
+
+	"github.com/letsencrypt/crl-monitor/retryhttp"
 )
 
 type BoulderAPIFetcher struct {
-	Client  *http.Client
 	BaseURL string
-}
-
-func (baf *BoulderAPIFetcher) getBody(ctx context.Context, url string) ([]byte, error) {
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	req.Header.Set("User-Agent", "CRL-Monitor/0.1")
-	resp, err := baf.Client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	body, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return nil, err
-	}
-
-	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("http status %d (%s)", resp.StatusCode, string(body))
-	}
-
-	return body, nil
-}
-
-// getWithRetries is a simple wrapper around client.Do that will retry on a fixed backoff schedule
-func (baf *BoulderAPIFetcher) getWithRetries(ctx context.Context, url string) ([]byte, error) {
-	// A fixed sequence of retries. We start with 0 seconds, retrying
-	// immediately, and increase a few seconds between each retry. The final
-	// value is zero so that we don't sleep before returning the final error.
-	var err error
-	for _, backoff := range []int{0, 1, 1, 2, 3, 0} {
-		var body []byte
-		body, err = baf.getBody(ctx, url)
-		if err == nil {
-			return body, nil
-		}
-		time.Sleep(time.Duration(backoff) * time.Second)
-	}
-	return nil, err
 }
 
 // FetchNotAfter downloads a certificate, parses it, and returns the NotAfter on
@@ -65,19 +22,19 @@ func (baf *BoulderAPIFetcher) FetchNotAfter(ctx context.Context, serial *big.Int
 	// The baseURL is followed by a hex-encoded serial
 	url := fmt.Sprintf("%s/%036x", baf.BaseURL, serial)
 
-	body, err := baf.getWithRetries(ctx, url)
+	body, err := retryhttp.Get(ctx, url)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error fetching NotAfter for serial %d: %w", serial, err)
+		return time.Time{}, fmt.Errorf("fetching NotAfter for serial %d: %w", serial, err)
 	}
 
 	block, _ := pem.Decode(body)
 	if block == nil {
-		return time.Time{}, fmt.Errorf("error parsing PEM for serial %d: %s", serial, string(body))
+		return time.Time{}, fmt.Errorf("parsing PEM for serial %d: %s", serial, string(body))
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("error parsing certificate for serial %d: %w", serial, err)
+		return time.Time{}, fmt.Errorf("parsing certificate for serial %d: %w", serial, err)
 	}
 
 	return cert.NotAfter, nil

--- a/checker/expiry/boulder_api_test.go
+++ b/checker/expiry/boulder_api_test.go
@@ -123,7 +123,7 @@ func TestBoulderAPIFetcher(t *testing.T) {
 		res.Write([]byte(testCert))
 	}))
 
-	fetcher := BoulderAPIFetcher{BaseURL: testServer.URL + somePrefix, Client: http.DefaultClient}
+	fetcher := BoulderAPIFetcher{BaseURL: testServer.URL + somePrefix}
 
 	serial := new(big.Int)
 	serial.SetString(serialhex, 16)

--- a/checker/expiry/integration_test.go
+++ b/checker/expiry/integration_test.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"fmt"
 	"math/big"
-	"net/http"
 	"testing"
 	"time"
 
@@ -36,7 +35,7 @@ func TestBoulderAPI(t *testing.T) {
 	} {
 		t.Run(tc.subdomain, func(t *testing.T) {
 			baseURL := fmt.Sprintf("https://%s.api.letsencrypt.org/get/cert", tc.subdomain)
-			baf := BoulderAPIFetcher{Client: http.DefaultClient, BaseURL: baseURL}
+			baf := BoulderAPIFetcher{BaseURL: baseURL}
 
 			serial := new(big.Int)
 			serial.SetString(tc.serial, 16)

--- a/retryhttp/retryhttp.go
+++ b/retryhttp/retryhttp.go
@@ -1,0 +1,51 @@
+package retryhttp
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+func getBody(ctx context.Context, url string) ([]byte, error) {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	req.Header.Set("User-Agent", "CRL-Monitor/0.1")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("http status %d (%s)", resp.StatusCode, string(body))
+	}
+
+	return body, nil
+}
+
+// Get is a simple wrapper around http.Client.Do that will retry on a fixed backoff schedule
+func Get(ctx context.Context, url string) ([]byte, error) {
+	// A fixed sequence of retries. We start with 0 seconds, retrying
+	// immediately, and increase a few seconds between each retry. The final
+	// value is zero so that we don't sleep before returning the final error.
+	var err error
+	for _, backoff := range []int{0, 1, 1, 2, 3, 0} {
+		var body []byte
+		body, err = getBody(ctx, url)
+		if err == nil {
+			return body, nil
+		}
+		time.Sleep(time.Duration(backoff) * time.Second)
+	}
+	return nil, err
+}


### PR DESCRIPTION
This provides a little easy assurance that the public-facing URLs in certificates are resolvable and verifiable by the issuers of the specific certificates we're issuing.

Since this introduces another HTTP fetch, factor out the HTTP retry code from BoulderAPIFetcher into a new `retryhttp` package.