### PR TITLE
checker: format serial as hex in error messages

### DIFF
--- a/checker/expiry/boulder_api.go
+++ b/checker/expiry/boulder_api.go
@@ -20,22 +20,26 @@ type BoulderAPIFetcher struct {
 // serial. So it is specific to Boulder's API, not a generic ACME API client.
 func (baf *BoulderAPIFetcher) FetchNotAfter(ctx context.Context, serial *big.Int) (time.Time, error) {
 	// The baseURL is followed by a hex-encoded serial
-	url := fmt.Sprintf("%s/%036x", baf.BaseURL, serial)
+	url := fmt.Sprintf("%s/%s", baf.BaseURL, formatSerial(serial))
 
 	body, err := retryhttp.Get(ctx, url)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("fetching NotAfter for serial %d: %w", serial, err)
+		return time.Time{}, fmt.Errorf("fetching NotAfter for serial %s: %w", formatSerial(serial), err)
 	}
 
 	block, _ := pem.Decode(body)
 	if block == nil {
-		return time.Time{}, fmt.Errorf("parsing PEM for serial %d: %s", serial, string(body))
+		return time.Time{}, fmt.Errorf("parsing PEM for serial %s: %s", formatSerial(serial), string(body))
 	}
 
 	cert, err := x509.ParseCertificate(block.Bytes)
 	if err != nil {
-		return time.Time{}, fmt.Errorf("parsing certificate for serial %d: %w", serial, err)
+		return time.Time{}, fmt.Errorf("parsing certificate for serial %s: %s", formatSerial(serial), err)
 	}
 
 	return cert.NotAfter, nil
+}
+
+func formatSerial(serial *big.Int) string {
+	return fmt.Sprintf("%036x", serial)
 }


### PR DESCRIPTION
The base-10 representation of the serial is not very helpful in error messages, because we have to convert it before it's useful. Instead, print the serial in the same representation that we sent it to the boulder API.