### PR TITLE
Detect duplicate CRL versions

### DIFF
--- a/checker/earlyremoval/check.go
+++ b/checker/earlyremoval/check.go
@@ -1,6 +1,7 @@
 package earlyremoval
 
 import (
+	"bytes"
 	"context"
 	"crypto/x509"
 	"log"
@@ -53,6 +54,19 @@ func sample[T any](input []T, max int) []T {
 
 // Check for early removal.  If maxFetch is greater than 0, only check that many serials
 func Check(ctx context.Context, fetcher Fetcher, maxFetch int, prev *x509.RevocationList, crl *x509.RevocationList) ([]EarlyRemoval, error) {
+	// In rare cases, a duplicate CRL version may be uploaded. This causes a flake,
+	// because checker.Diff() expects CRLs to be increasing in version number. It is
+	// valid for duplicate versions to be uploaded, as long as they're bit-for-bit
+	// identical.
+	//
+	// We'll skip this check if the CRLs are identical. We would have checked the
+	// previous CRL version already, so we don't have any work to do on the newer
+	// version.
+	if len(crl.Raw) > 0 && bytes.Equal(prev.Raw, crl.Raw) {
+		log.Printf("previous and current CRL (number %d) are identical; skipping early removal check", crl.Number)
+		return nil, nil
+	}
+
 	diff, err := checker.Diff(prev, crl)
 	if err != nil {
 		return nil, err

--- a/checker/earlyremoval/check_test.go
+++ b/checker/earlyremoval/check_test.go
@@ -33,6 +33,11 @@ func TestCheck(t *testing.T) {
 		{name: "no removals", prev: &testdata.CRL1, crl: &testdata.CRL2},
 		{name: "remove 1", prev: &testdata.CRL2, crl: &testdata.CRL3},
 		{
+			name: "bit-for-bit identical CRL",
+			prev: &x509.RevocationList{Raw: []byte{0x30, 0x01, 0x00}, Number: big.NewInt(2)},
+			crl:  &x509.RevocationList{Raw: []byte{0x30, 0x01, 0x00}, Number: big.NewInt(2)},
+		},
+		{
 			name: "early removal",
 			prev: &testdata.CRL3,
 			crl:  &testdata.CRL4,


### PR DESCRIPTION
In rare cases, two versions of the same CRL shard may be identical. Handle that case appropriately.