### PR TITLE
Output actual version string rather than a pointer address

### DIFF
--- a/checker/checker.go
+++ b/checker/checker.go
@@ -113,6 +113,14 @@ type Checker struct {
 	issuers  map[string]*x509.Certificate
 }
 
+// storageKey is nearly analogous to storage.Key, except that the Version field
+// is a string
+type storageKey struct {
+	Bucket  string
+	Object  string
+	Version string
+}
+
 // crlSummary is a subset of fields from *x509.RevocationList
 // useful for logging, plus the number of entries and some metadata.
 type crlSummary struct {
@@ -121,7 +129,7 @@ type crlSummary struct {
 	ThisUpdate time.Time
 	NextUpdate time.Time
 	URL        string
-	StorageKey storage.Key
+	StorageKey storageKey
 }
 
 func summary(crl *x509.RevocationList, key storage.Key) crlSummary {
@@ -133,7 +141,11 @@ func summary(crl *x509.RevocationList, key storage.Key) crlSummary {
 		Number:     crl.Number,
 		NumEntries: len(crl.RevokedCertificateEntries),
 		URL:        idp,
-		StorageKey: key,
+		StorageKey: storageKey{
+			Bucket:  key.Bucket,
+			Object:  key.Object,
+			Version: key.VersionString(),
+		},
 	}
 }
 

--- a/checker/checker_test.go
+++ b/checker/checker_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/letsencrypt/crl-monitor/checker/testdata"
 	"github.com/letsencrypt/crl-monitor/db"
 	dbmock "github.com/letsencrypt/crl-monitor/db/mock"
+	"github.com/letsencrypt/crl-monitor/storage"
 	storagemock "github.com/letsencrypt/crl-monitor/storage/mock"
 )
 
@@ -163,4 +164,32 @@ func Test_nameID(t *testing.T) {
 			require.Equal(t, tt.want, nameID(issuer))
 		})
 	}
+}
+
+func TestLogSummaryFormatsVersionCorrectly(t *testing.T) {
+	issuer, key := testdata.MakeIssuer(t)
+	issuerName := nameID(issuer)
+	object := fmt.Sprintf("%s/0.crl", issuerName)
+	idpURL := fmt.Sprintf("http://idp/%s", object)
+
+	crl1der := testdata.MakeCRL(t, &testdata.CRL1, idpURL, issuer, key)
+	crl2der := testdata.MakeCRL(t, &testdata.CRL2, idpURL, issuer, key)
+
+	crl1, err := x509.ParseRevocationList(crl1der)
+	require.NoError(t, err)
+	crl2, err := x509.ParseRevocationList(crl2der)
+	require.NoError(t, err)
+
+	oldVer := "oldy"
+	newVer := "newy"
+
+	result := logSummary(
+		crl1, storage.Key{Bucket: "b", Object: object, Version: &oldVer},
+		crl2, storage.Key{Bucket: "b", Object: object, Version: &newVer},
+	)
+
+	formatted := fmt.Sprintf("%+v", result)
+	require.NotContains(t, formatted, "0x", "formatted summary shouldn't contain pointer addresses, but did")
+	require.Contains(t, formatted, "oldy")
+	require.Contains(t, formatted, "newy")
 }

--- a/storage/storage.go
+++ b/storage/storage.go
@@ -26,6 +26,14 @@ type Key struct {
 	Version        *string
 }
 
+// VersionString returns the version string or "unknown" if unset.
+func (k Key) VersionString() string {
+	if k.Version == nil {
+		return "unknown"
+	}
+	return *k.Version
+}
+
 func New(ctx context.Context) *Storage {
 	cfg, err := config.LoadDefaultConfig(ctx)
 	if err != nil {
@@ -47,12 +55,12 @@ func (s *Storage) Fetch(ctx context.Context, key Key) ([]byte, string, error) {
 		VersionId: key.Version,
 	})
 	if err != nil {
-		return nil, "", fmt.Errorf("retrieving CRL %s %s version %v: %w", key.Bucket, key.Object, key.Version, err)
+		return nil, "", fmt.Errorf("retrieving CRL %s %s version %s: %w", key.Bucket, key.Object, key.VersionString(), err)
 	}
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, "", fmt.Errorf("reading CRL %s %s version %v: %w", key.Bucket, key.Object, key.Version, err)
+		return nil, "", fmt.Errorf("reading CRL %s %s version %s: %w", key.Bucket, key.Object, key.VersionString(), err)
 	}
 
 	return body, *resp.VersionId, err
@@ -86,7 +94,7 @@ func (s *Storage) Previous(ctx context.Context, key Key) (string, error) {
 	}
 
 	if (!found || prevVersion == nil) && resp.IsTruncated != nil && *resp.IsTruncated {
-		return "", fmt.Errorf("too many versions and pagination not implemented! %+v", key)
+		return "", fmt.Errorf("too many versions and pagination not implemented! bucket:%s object:%s version:%s", key.Bucket, key.Object, key.VersionString())
 	}
 
 	if !found {

--- a/storage/storage_test.go
+++ b/storage/storage_test.go
@@ -11,6 +11,30 @@ import (
 	"github.com/letsencrypt/crl-monitor/storage/mock"
 )
 
+func TestKeyVersionString(t *testing.T) {
+	v := "abc123"
+	for _, tt := range []struct {
+		name     string
+		key      storage.Key
+		expected string
+	}{
+		{
+			name:     "version exists",
+			key:      storage.Key{Bucket: "b", Object: "o", Version: &v},
+			expected: "abc123",
+		},
+		{
+			name:     "version is nil",
+			key:      storage.Key{Bucket: "b", Object: "o", Version: nil},
+			expected: "unknown",
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			require.Equal(t, tt.expected, tt.key.VersionString())
+		})
+	}
+}
+
 func TestStorage(t *testing.T) {
 	mockStorage := mock.New(t, "somebucket", map[string][]mock.MockObject{
 		"123/0.crl": {


### PR DESCRIPTION
We've seen alerts such as the following where we see `Version:0xc0007f8090` which is unhelpful.
```
checking for early removal: old CRL does not precede new CRL. context: {Old:{Number:+1777047686349361882 NumEntries:227 ThisUpdate:2026-04-24 16:21:26 +0000 UTC NextUpdate:2026-05-03 16:21:25 +0000 UTC URL:http://ye1.c.lencr.org/91.crl StorageKey:{Bucket:le-crl-prod Object:15121864070385704/91.crl Version:0xc000830700}} New:{Number:+1777047686349361882 NumEntries:227 ThisUpdate:2026-04-24 16:21:26 +0000 UTC NextUpdate:2026-05-03 16:21:25 +0000 UTC URL:http://ye1.c.lencr.org/91.crl StorageKey:{Bucket:le-crl-prod Object:15121864070385704/91.crl Version:0xc0007f8090}}}
```

Adds `k.VersionString()` method to dereference the pointer into a string.